### PR TITLE
Adding support for create datasources using URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ build
 *.egg-info
 *.egg
 *.coverage
-
+set_credentials.sh

--- a/bigml/api.py
+++ b/bigml/api.py
@@ -484,6 +484,15 @@ class BigML(object):
             'object': resource,
             'error': error}
 
+    def create_source_from_url(self, url, args=None):
+        """Create a new source."""
+        if args is None:
+            args = {}
+        args.update({
+            "remote": url})
+        body = json.dumps(args)
+        return self._create(SOURCE_URL, body)
+
     def get_source(self, source):
         """Retrieve a source."""
         if isinstance(source, dict) and 'resource' in source:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     pass
 
-version = "0.1"
+version = "0.2"
 
 distutils.core.setup(
     name="bigml",

--- a/tests/features/create_prediction.feature
+++ b/tests/features/create_prediction.feature
@@ -15,3 +15,17 @@ Feature: Create Predictions
         Examples:
         | data                | time_1  | time_2 | time_3 | data_input    | objective | prediction  |
         | ../data/iris.csv | 10      | 10     | 10     | {"petal length": 1} | 000004    | Iris-setosa |
+    
+    Scenario: Successfully creating a prediction from a source in a remote location:
+        Given I create a data source using the url "<url>"
+        And I wait until the source is ready less than <time_1> secs
+        And I create a dataset
+        And I wait until the dataset is ready less than <time_2> secs
+        And I create a model
+        And I wait until the model is ready less than <time_3> secs
+        When I create a prediction for "<data_input>"
+        Then the prediction for "<objective>" is "<prediction>"
+
+        Examples:
+        | url                | time_1  | time_2 | time_3 | data_input    | objective | prediction  |
+        | s3://bigml-public/csv/iris.csv | 10      | 10     | 10     | {"petal length": 1} | 000004    | Iris-setosa |

--- a/tests/features/create_source-steps.py
+++ b/tests/features/create_source-steps.py
@@ -36,6 +36,16 @@ def i_upload_a_file(step, file):
     # save reference
     world.sources.append(resource['resource'])
 
+@step(r'I create a data source using the url "(.*)"')
+def i_create_using_url(step, url):
+    resource = world.api.create_source_from_url(url)
+    # update status
+    world.status = resource['code']
+    world.location = resource['location']
+    world.source = resource['object']
+    # save reference
+    world.sources.append(resource['resource'])
+
 @step(r'the source has been created')
 def the_source_has_been_created(step):
     assert world.status == HTTP_CREATED


### PR DESCRIPTION
I modified a bit the binding giving support to create new datasources using a URL as is documented in [BigML Developers](https://bigml.com/developers) - "Creating a source using a URL".

I added the method `create_source_from_url(self, url, args=None)` to `bigml/api.py`. Please feel free to modify it at your convenience.

I also added a test checking the new feature.
