### PR TITLE
Change default username/api_key args to None

### DIFF
--- a/bigml/api.py
+++ b/bigml/api.py
@@ -128,7 +128,17 @@ class BigML(object):
         https://bigml.com/developers
     """
     def __init__(self, username=None, api_key=None, dev_mode=False):
-        """Initialize httplib and set up username and api_key."""
+        """Initialize the BigML API.
+
+        If left unspecified, `username` and `api_key` will default to the
+        values of the `BIGML_USERNAME` and `BIGML_API_KEY` environment
+        variables respectively.
+
+        If `dev_mode` is set to `True`, the API will be used in development
+        mode where the size of your datasets are limited but you are not
+        charged any credits.
+
+        """
         if username is None:
             username = os.environ['BIGML_USERNAME']
         if api_key is None:


### PR DESCRIPTION
In Python, the values of default arguments are created once when the
function/method is defined; they are not re-evaluated each time the
function/method is called.

By using `username=os.environ['BIGML_USERNAME']` as the default argument
to BigML's constructor, the value of the BIGML_USERNAME environment
variable _at the time the module is imported_ will remain the default
value until the interpreter exits, even if the value of the environment
variable changes.

Before this change:

```
>>> from bigml.api import *
>>> BigML(api_key='***').auth
'?username=njwilson;api_key=***;'
>>> os.environ['BIGML_USERNAME'] = 'joebob'
>>> BigML(api_key='***').auth
'?username=njwilson;api_key=***;'      <--- Should be 'joebob'
```

After this change:

```
>>> from bigml.api import *
>>> BigML(api_key='***').auth
'?username=njwilson;api_key=***;'
>>> os.environ['BIGML_USERNAME'] = 'joebob'
>>> BigML(api_key='***').auth
'?username=joebob;api_key=***;'
```

In practice, it probably doesn't matter in this case as the environment
variables shouldn't be changing. However, I ran into a problem when I
was automatically generating some API documentation and the output was
showing:

```
class bigml.api.BigML(username='njwilson', ...)
```

(The documentation contained my username and API key)
