### PR TITLE
Use prediction_domain for all prediction methods

### DIFF
--- a/bigml/anomalyscorehandler.py
+++ b/bigml/anomalyscorehandler.py
@@ -48,7 +48,7 @@ class AnomalyScoreHandler(ResourceHandler):
            instantiated independently.
 
         """
-        self.anomaly_score_url = self.url + ANOMALY_SCORE_PATH
+        self.anomaly_score_url = self.prediction_base_url + ANOMALY_SCORE_PATH
 
     def create_anomaly_score(self, anomaly, input_data=None,
                              args=None, wait_time=3, retries=10):

--- a/bigml/batchpredictionhandler.py
+++ b/bigml/batchpredictionhandler.py
@@ -46,7 +46,8 @@ class BatchPredictionHandler(ResourceHandler):
            instantiated independently.
 
         """
-        self.batch_prediction_url = self.url + BATCH_PREDICTION_PATH
+        self.batch_prediction_url = (self.prediction_base_url +
+                                     BATCH_PREDICTION_PATH)
 
     def create_batch_prediction(self, model, dataset,
                                 args=None, wait_time=3, retries=10):

--- a/bigml/bigmlconnection.py
+++ b/bigml/bigmlconnection.py
@@ -239,7 +239,7 @@ class BigMLConnection(object):
         self.verify = None
         self.verify_prediction = None
         self.url = None
-        self.prediction_url = None
+        self.prediction_base_url = None
 
         self._set_api_urls(domain=domain)
 
@@ -276,7 +276,7 @@ class BigMLConnection(object):
         self.verify = domain.verify
         self.verify_prediction = domain.verify_prediction
         self.url = BIGML_URL % (BIGML_PROTOCOL, self.general_domain)
-        self.prediction_url = BIGML_URL % (
+        self.prediction_base_url = BIGML_URL % (
             self.prediction_protocol, self.prediction_domain)
 
 

--- a/bigml/centroidhandler.py
+++ b/bigml/centroidhandler.py
@@ -47,7 +47,7 @@ class CentroidHandler(ResourceHandler):
            instantiated independently.
 
         """
-        self.centroid_url = self.url + CENTROID_PATH
+        self.centroid_url = self.prediction_base_url + CENTROID_PATH
 
     def create_centroid(self, cluster, input_data=None,
                         args=None, wait_time=3, retries=10):

--- a/bigml/forecasthandler.py
+++ b/bigml/forecasthandler.py
@@ -46,7 +46,7 @@ class ForecastHandler(ResourceHandler):
            instantiated independently.
 
         """
-        self.forecast_url = self.url + FORECAST_PATH
+        self.forecast_url = self.prediction_base_url + FORECAST_PATH
 
     def create_forecast(self, time_series, input_data=None,
                         args=None, wait_time=3, retries=10):

--- a/bigml/predictionhandler.py
+++ b/bigml/predictionhandler.py
@@ -47,7 +47,7 @@ class PredictionHandler(ResourceHandler):
            instantiated independently.
 
         """
-        self.prediction_url = self.prediction_url + PREDICTION_PATH
+        self.prediction_url = self.prediction_base_url + PREDICTION_PATH
 
     def create_prediction(self, model, input_data=None,
                           args=None, wait_time=3, retries=10):

--- a/bigml/projectionhandler.py
+++ b/bigml/projectionhandler.py
@@ -47,7 +47,7 @@ class ProjectionHandler(ResourceHandler):
            instantiated independently.
 
         """
-        self.projection_url = self.url + PROJECTION_PATH
+        self.projection_url = self.prediction_base_url + PROJECTION_PATH
 
     def create_projection(self, pca, input_data=None,
                           args=None, wait_time=3, retries=10):


### PR DESCRIPTION
Currently, when the api is instantiated with a value for `prediction_domain`, that value is only used for calls to `create_prediction`, and not other prediction-like methods such as `create_batch_prediction`, `create_centroid`, `create_anomaly_score`, etc.

This PR changes the handlers for those methods to use the value for `prediction_domain`.