### PR TITLE
Make temporary file stick around after close

### DIFF
--- a/bigml/deepnet.py
+++ b/bigml/deepnet.py
@@ -145,7 +145,7 @@ def remote_preprocess(image_file):
             ratio = width / height
             image = image.resize((int(ratio * TOP_SIZE), TOP_SIZE),
                                   Image.BICUBIC)
-    with tempfile.NamedTemporaryFile() as temp_fp:
+    with tempfile.NamedTemporaryFile(delete=False) as temp_fp:
         tmp_file_name = os.path.join(TEMP_DIR, "%s.jpg" % temp_fp.name)
         # compressing to 90%
         image.save(tmp_file_name, quality=90)


### PR DESCRIPTION
According to the [docs](https://docs.python.org/3.9/library/tempfile.html?highlight=namedtemporaryfile#tempfile.NamedTemporaryFile)
By default the file returned by this function is deleted automatically after close.
With this change we make sure that the file sticks around after the file is closed (on exit of the with block).

However, I was not able to reproduce this behavior on Python 3.9.13 on a mac M1, 
I think we should explicitly ask for the file to be kept around so it can be used later.