### PR TITLE
added operation_settings to logistic call of parse_operating_point

### DIFF
--- a/bigml/logistic.py
+++ b/bigml/logistic.py
@@ -262,7 +262,8 @@ class LogisticRegression(ModelFields):
         """
 
         kind, threshold, positive_class = parse_operating_point( \
-            operating_point, ["probability"], self.class_names)
+            operating_point, ["probability"], 
+            self.class_names, self.operation_settings)
         predictions = self.predict_probability(input_data, False)
         position = self.class_names.index(positive_class)
         if predictions[position][kind] > threshold:


### PR DESCRIPTION
logistic models call of parse_operating_point was missing the operation_settings arg so it was failing on every call to it when working with local models.