### PR TITLE
Categorical training data example generated based on the category distributions

### DIFF
--- a/bigml/fields.py
+++ b/bigml/fields.py
@@ -679,9 +679,9 @@ class Fields():
                     if missings and random.randint(0, 5) > 3:
                         value = None
                     else:
-                        categories_number = len(field["summary"]["categories"])
-                        index = random.randint(0, categories_number - 1)
-                        value = field["summary"]["categories"][index][0]
+                        categories = [cat[0] for cat in field["summary"]["categories"]]
+                        weights = [cat[1] for cat in field["summary"]["categories"]]
+                        value = random.choices(categories, weights)[0]
                 if optype == "text":
                     if missings and random.randint(0, 5) > 3:
                         value = None


### PR DESCRIPTION
Taking advantage about the random.choices feature to select a categorical value providing the distribution of the values.

- I've applied only to the `categorical` fields. Not sure if it can be done with the `text` and `items`  ... but if the idea is accepted, I imagine that it could be applied to them too.